### PR TITLE
Fixes #5 and update close-tab shortcut to have modifier

### DIFF
--- a/app/helpers/settings.ts
+++ b/app/helpers/settings.ts
@@ -277,7 +277,7 @@ const nightpdf_schema: Schema<NightPDFSettings> = {
   keybinds: {
     properties: {
       OpenWindow: keybindPropertyDef(),
-      CloseWindow: keybindPropertyDef(),
+      CloseTab: keybindPropertyDef(),
       ReOpen: keybindPropertyDef(),
       SwitchTab: keybindPropertyDef(),
       PreviousTab: keybindPropertyDef(),
@@ -302,17 +302,20 @@ function nightpdf_default_settings(version: string): NightPDFSettings {
     },
     keybinds: {
       OpenWindow: {
-        keybind: KeybindHelper.keybindFromTriggerArray(["Ctrl+T"]),
+        keybind: KeybindHelper.keybindFromTriggerArray(["CmdOrCtrl+t"]),
         action: "openNewPDF",
         displayName: "Open New PDF",
       },
-      CloseWindow: {
-        keybind: KeybindHelper.keybindFromTriggerArray(["Ctrl+w", "Ctrl+F4"]),
+      CloseTab: {
+        keybind: KeybindHelper.keybindFromTriggerArray([
+          "CmdOrCtrl+w",
+          "Ctrl+F4",
+        ]),
         action: "close-tab",
         displayName: "Close Tab",
       },
       ReOpen: {
-        keybind: KeybindHelper.keybindFromTriggerArray(["Ctrl+Shift+T"]),
+        keybind: KeybindHelper.keybindFromTriggerArray(["CmdOrCtrl+Shift+t"]),
         action: "reopen-tab",
         displayName: "Reopen Tab",
       },
@@ -365,8 +368,8 @@ function nightpdf_default_settings(version: string): NightPDFSettings {
 
 // The modifier keys allowed in NightPDF
 const ModifierKeys: ModifierKeyMap = {
-  CommandOrControl: {
-    savesAs: "Ctrl",
+  CmdOrCtrl: {
+    savesAs: "CmdOrCtrl",
     osDependent: true,
     osVariants: {
       darwin: "⌘",

--- a/app/render/index.ts
+++ b/app/render/index.ts
@@ -135,6 +135,17 @@ async function nightPDF() {
       },
       true,
     );
+    // Listen for the tab-removed event
+    tabGroup?.on("tab-removed", async (tab, tabGroup) => {
+      console.log(`Tab with title "${tab.title}" was closed.`);
+      const closed = tabFilePath.get(tab);
+      const settings = await window.api.GetSettings();
+      const files = [...settings.openedFiles];
+      const openedFiles = files.filter((f) => {
+        return f !== closed;
+      });
+      await window.api.SetOpenedFiles(openedFiles);
+    });
   });
 
   //setup electron listeners
@@ -208,14 +219,6 @@ async function nightPDF() {
     if (tab) {
       console.log("Closing active tab.");
       console.log("tab is ", tab);
-      // let closed = sessionStorage.getItem(tab.id.toString());
-      const closed = tabFilePath.get(tab);
-      const settings = await window.api.GetSettings();
-      const files = [...settings.openedFiles];
-      const openedFiles = files.filter((f) => {
-        return f !== closed;
-      });
-      await window.api.SetOpenedFiles(openedFiles);
       tab.close(false);
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knightpdf",
-  "version": "v3.0.0-beta5",
+  "version": "v3.0.0-beta6",
   "description": "Dark Mode for PDFs",
   "main": "out/main/app.js",
   "packageManager": "yarn@4.1.1",


### PR DESCRIPTION
Update the close-tab shortcut to be `Cmd / Ctrl + w`.
This is consistent with shortcuts of common browsers on MacOS.
More importantly, it prevents accidentally closing the tab when searching for something containing `w`.
2nd commit fixes #5.